### PR TITLE
Use ESM, and update rdf-ext

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,25 +10,26 @@ Utils for RDFJS Datasets.
 Each util function can be loaded as property from the main module or by loading only the file with the same name.
 Loading the individual files can decrease the file size after packaging the JavaScript code for the browser.
 
-### Example
+### Usage
 
 Loading the function from the main module:
 
-    const resource = require('rdf-utils-dataset').resource
- 
+```js
+import { resource } from 'rdf-utils-dataset'
+```
+
 Loading the function from the file with the function name:
 
-    const resource = require('rdf-utils-dataset/resource')
+```js
+import { resource } from 'rdf-utils-dataset/resource.js'
+```
 
 ## Functions
 
 ### resource(input, subject)
 
-Returns a subgraph of `input`.
-It's created by traversing `input` starting at subject.
-Traversing stops at quads with a `NamedNode` subject.
+Returns a subgraph of `input`. It's created by traversing `input` starting at subject. Traversing stops at quads with a `NamedNode` subject.
 
 ### resourcesToGraph (input, options)
 
-Searches for all `NamedNode` subjects in `input` and creates subgraphs using `resource()`.
-The graph of the quads are set to the start subject.  
+Searches for all `NamedNode` subjects in `input` and creates subgraphs using `resource()`. The graph of the quads are set to the start subject.  

--- a/README.md
+++ b/README.md
@@ -5,17 +5,99 @@
 
 Utils for RDFJS Datasets.
 
-## Usage
+## Functions
 
-Each util function can be loaded as property from the main module or by loading only the file with the same name.
-Loading the individual files can decrease the file size after packaging the JavaScript code for the browser.
+### resource(dataset, subject)
+
+Returns a subgraph of `dataset`. It's created by traversing `dataset` starting at subject. Traversing stops at quads with a `NamedNode` subject.
+
+#### Example
+
+Say you have the following triples in a *dataset*:
+
+```turtle
+@prefix ex:<http://example.org/>.
+
+ex:Alice
+    ex:address [ ex:street "Wonderland Street" ;
+                 ex:number "22" ] ;
+    ex:name "Alice" .
+
+ex:Bob
+    ex:name "Bob" .
+```
+
+Then, the *resource* function
+
+```js
+import { resource } from 'rdf-utils-dataset'
+
+const dataset = // Load the dataset somehow
+const result = resource(dataset, rdf.namedNode('http://example.org/Alice'))
+console.log(result.toCanonical())
+```
+
+yields:
+
+```n3
+<http://example.org/Alice> <http://example.org/address> _:c14n0 .
+<http://example.org/Alice> <http://example.org/name> "Alice" .
+_:c14n0 <http://example.org/number> "22" .
+_:c14n0 <http://example.org/street> "WonderLand Street" .
+```
+
+(Note that the description follows blank nodes)
+
+### resourcesToGraph (dataset, options)
+
+Searches for all `NamedNode` subjects in `dataset` and creates subgraphs using `resource()`. The graph of the quads are set to the start subject.  
+
+### Example
+
+Say you have the following triples in a *dataset*:
+
+```turtle
+@prefix ex:<http://example.org/>.
+
+ex:Alice
+    ex:address [ ex:street "Wonderland Street" ;
+                 ex:number "22" ] ;
+    ex:name "Alice" .
+
+ex:Bob
+    ex:name "Bob" .
+```
+
+Then, the *resourcesToGraph* function
+
+```js
+import { resourcesToGraph } from 'rdf-utils-dataset'
+
+const dataset = // Load the dataset somehow
+const result = resourcesToGraph(dataset)
+console.log(result.toCanonical())
+```
+
+yields:
+
+```n3
+<http://example.org/Alice> <http://example.org/address> _:c14n0 <http://example.org/Alice> .
+<http://example.org/Alice> <http://example.org/name> "Alice" <http://example.org/Alice> .
+<http://example.org/Bob> <http://example.org/name> "Bob" <http://example.org/Bob> .
+_:c14n0 <http://example.org/number> "22" <http://example.org/Alice> .
+_:c14n0 <http://example.org/street> "WonderLand Street" <http://example.org/Alice> .
+```
+
+## Loading the functions
+
+Each util function can be loaded as property from the main module or by loading only the file with the same name. Loading the individual files can decrease the file size after packaging the JavaScript code for the browser.
 
 ### Usage
 
 Loading the function from the main module:
 
 ```js
-import resource from 'rdf-utils-dataset'
+import { resource } from 'rdf-utils-dataset'
 ```
 
 Loading the function from the file with the function name:
@@ -23,13 +105,3 @@ Loading the function from the file with the function name:
 ```js
 import resource from 'rdf-utils-dataset/resource.js'
 ```
-
-## Functions
-
-### resource(input, subject)
-
-Returns a subgraph of `input`. It's created by traversing `input` starting at subject. Traversing stops at quads with a `NamedNode` subject.
-
-### resourcesToGraph (input, options)
-
-Searches for all `NamedNode` subjects in `input` and creates subgraphs using `resource()`. The graph of the quads are set to the start subject.  

--- a/README.md
+++ b/README.md
@@ -15,13 +15,13 @@ Loading the individual files can decrease the file size after packaging the Java
 Loading the function from the main module:
 
 ```js
-import { resource } from 'rdf-utils-dataset'
+import resource from 'rdf-utils-dataset'
 ```
 
 Loading the function from the file with the function name:
 
 ```js
-import { resource } from 'rdf-utils-dataset/resource.js'
+import resource from 'rdf-utils-dataset/resource.js'
 ```
 
 ## Functions

--- a/benchmark/ontology.js
+++ b/benchmark/ontology.js
@@ -1,13 +1,11 @@
-const fs = require('fs')
-const rdf = require('rdf-ext')
-const N3Parser = require('rdf-parser-n3')
-const Readable = require('readable-stream').Readable
-
-module.exports = deserialize
+import fs from 'fs'
+import rdf from 'rdf-ext'
+import N3Parser from 'rdf-parser-n3'
+import Readable from 'readable-stream'
 
 async function deserialize () {
   const parser = new N3Parser({ factory: rdf })
-  const string = fs.readFileSync(require.resolve('./ontology.nt'))
+  const string = fs.readFileSync('./ontology.nt')
 
   const input = new Readable({
     read: () => {
@@ -20,3 +18,5 @@ async function deserialize () {
 
   return rdf.dataset().import(quadStream)
 }
+
+export default deserialize

--- a/benchmark/resourcesToGraph.js
+++ b/benchmark/resourcesToGraph.js
@@ -1,7 +1,12 @@
-const resourcesToGraph = require('../resourcesToGraph')
-require('./ontology')().then(dataset => {
+import resourcesToGraph from '../resourcesToGraph.js'
+import deserialize from './ontology.js'
+
+async function logTimes () {
+  const dataset = await deserialize()
   let TEST = `resourcesToGraph`
   console.time(TEST)
   resourcesToGraph(dataset)
   console.timeEnd(TEST)
-})
+}
+
+logTimes()

--- a/index.js
+++ b/index.js
@@ -1,3 +1,7 @@
-module.exports = {
-  resource: require('./resource')
+import resource from './resource.js'
+import resourcesToGraph from './resourcesToGraph.js'
+
+export {
+  resource,
+  resourcesToGraph
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rdf-utils-dataset",
-  "version": "2.0.0",
+  "version": "1.1.0",
   "type": "module",
   "description": "RDFJS Dataset utils",
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "rdf-utils-dataset",
-  "version": "1.1.0",
+  "version": "2.0.0",
+  "type": "module",
   "description": "RDFJS Dataset utils",
   "main": "index.js",
   "scripts": {
@@ -25,10 +26,10 @@
   "homepage": "https://github.com/rdf-ext/rdf-utils-dataset",
   "dependencies": {},
   "devDependencies": {
-    "mocha": "^3.5.3",
-    "rdf-ext": "^1.2.1",
+    "mocha": "^10.0.0",
+    "rdf-ext": "^2.0.1",
     "rdf-parser-n3": "^1.1.1",
-    "readable-stream": "^3.1.1",
+    "readable-stream": "^3.6.0",
     "standard": "^10.0.3"
   },
   "files": [

--- a/resource.js
+++ b/resource.js
@@ -9,20 +9,19 @@ function resource (_input, subject, cloned = false) {
     return quad.subject.equals(subject)
   })
 
-  if (quads.length > 0) {
-    quads.forEach(triple => {
-      if (triple.subject.termType !== 'BlankNode' && triple.object.termType !== 'BlankNode') {
-        input.remove(triple)
-      }
-    })
-    quads.forEach((quad) => {
-      if (quad.object.termType !== 'NamedNode') {
-        quads.addAll(resource(input, quad.object, true))
-      }
-    })
+  for (const triple of quads) {
+    if (triple.subject.termType !== 'BlankNode' && triple.object.termType !== 'BlankNode') {
+      input.delete(triple)
+    }
+  }
+
+  for (const quad of quads) {
+    if (quad.object.termType !== 'NamedNode') {
+      quads.addAll(resource(input, quad.object, true))
+    }
   }
 
   return quads
 }
 
-module.exports = resource
+export default resource

--- a/resource.js
+++ b/resource.js
@@ -1,10 +1,8 @@
 import rdf from 'rdf-ext'
 
-function resource (dataset, subject, cloned) {
-  const input = cloned ? dataset : dataset.clone()
-
+function resource (dataset, subject) {
   const siblings = rdf.termSet()
-  input.forEach(quad => {
+  dataset.forEach(quad => {
     if (quad.subject.value.split('#')[0] === subject.value.split('#')[0]) {
       siblings.add(quad.subject)
     }
@@ -18,7 +16,7 @@ function resource (dataset, subject, cloned) {
 
   const result = rdf.dataset()
   siblings.forEach((subject) => {
-    result.addAll(descriptionWithBlankNodes.match({ term: subject, dataset: input }))
+    result.addAll(descriptionWithBlankNodes.match({ term: subject, dataset: dataset }))
   })
   return result
 }

--- a/resourcesToGraph.js
+++ b/resourcesToGraph.js
@@ -1,8 +1,6 @@
 import rdf from 'rdf-ext'
 import resource from './resource.js'
 
-const cloned = true
-
 function resourcesToGraph (_input, options = {}) {
   const input = _input.clone()
   const factory = options.factory || rdf
@@ -22,7 +20,7 @@ function resourcesToGraph (_input, options = {}) {
 
   resourceIRIs.forEach((resourceIRI) => {
     const resourceNode = factory.namedNode(resourceIRI)
-    const resourceTriples = resource(input, resourceNode, cloned)
+    const resourceTriples = resource(input, resourceNode)
 
     resourceTriples.forEach(triple => {
       if (triple.subject.termType !== 'BlankNode') {

--- a/resourcesToGraph.js
+++ b/resourcesToGraph.js
@@ -1,5 +1,6 @@
-const rdf = require('rdf-ext')
-const resource = require('./resource')
+import rdf from 'rdf-ext'
+import resource from './resource.js'
+
 const cloned = true
 
 function resourcesToGraph (_input, options = {}) {
@@ -8,7 +9,7 @@ function resourcesToGraph (_input, options = {}) {
 
   const output = factory.dataset()
 
-  const resourceIRIs = input.toArray()
+  const resourceIRIs = [...input]
     .reduce((iriSet, quad) => {
       if (quad.subject.termType !== 'NamedNode') {
         return iriSet
@@ -25,7 +26,7 @@ function resourcesToGraph (_input, options = {}) {
 
     resourceTriples.forEach(triple => {
       if (triple.subject.termType !== 'BlankNode') {
-        input.remove(triple)
+        input.delete(triple)
       }
     })
 
@@ -35,4 +36,4 @@ function resourcesToGraph (_input, options = {}) {
   return output
 }
 
-module.exports = resourcesToGraph
+export default resourcesToGraph

--- a/test/resource.js
+++ b/test/resource.js
@@ -1,8 +1,8 @@
 /* global describe, it */
 
-const assert = require('assert')
-const rdf = require('rdf-ext')
-const resource = require('../resource')
+import assert from 'assert'
+import rdf from 'rdf-ext'
+import resource from '../resource.js'
 
 describe('resource', () => {
   it('should create sub graph for a resource', () => {

--- a/test/resourcesToGraph.js
+++ b/test/resourcesToGraph.js
@@ -1,11 +1,11 @@
 /* global describe, it */
 
-const assert = require('assert')
-const rdf = require('rdf-ext')
-const resourcesToGraph = require('../resourcesToGraph')
+import assert from 'assert'
+import rdf from 'rdf-ext'
+import resourcesToGraph from '../resourcesToGraph.js'
 
 describe('resourcesToGraph', () => {
-  it('should split resources in seperate graphs', () => {
+  it('should split resources in separate graphs', () => {
     const predicate = rdf.namedNode('http://example.org/predicate')
     const namedNode0 = rdf.namedNode('http://example.org/node0')
     const namedNode1 = rdf.namedNode('http://example.org/node1')
@@ -82,7 +82,7 @@ describe('resourcesToGraph', () => {
       }
     }
 
-    resourcesToGraph(input, {factory})
+    resourcesToGraph(input, { factory })
 
     assert.equal(count, 3)
   })


### PR DESCRIPTION
Hello @bergos, 

This pull request updates the rdf-ext lib and ports the code to ESM

I moved this one to ESM because it is a dependency of https://github.com/zazuko/trifid-handler-fetch, which is being ported to ESM using `"rdf-ext": "^2.0.1"`